### PR TITLE
Show summary always, allow optionally hiding reading time on non-blog pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -42,18 +42,12 @@
           {{ with .Description }}
             {{ . | markdownify }}
             {{ else }}
-            {{ if .Truncated }}
-              {{ .Summary }}
+            {{ .Summary | markdownify }}
+            {{ if and .Truncated (not .Params.hideReadMore) }}
+            <div><a class="read-more button" href="{{.RelPermalink}}">{{ $.Site.Params.ReadMore | default "Read more" }} →</a></div>
             {{ end }}
           {{ end }}
         </div>
-        {{ if not .Params.hideReadMore }}
-          <div>
-            <a class="read-more button" href="{{ .RelPermalink }}"
-              >{{ $.Site.Params.ReadMore | default "Read more" }} →</a
-            >
-          </div>
-        {{ end }}
       </div>
     {{ end }}
     {{ partial "pagination.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,7 +23,7 @@
         >{{ end }}
 
 
-      {{ if and $.Site.Params.ShowReadingTime (not .Param "hideReadingTime") }}
+      {{ if and $.Site.Params.ShowReadingTime (not .Params.hideReadingTime) }}
         <span class="post-read-time"
           >— {{ .ReadingTime }} {{ $.Site.Params.MinuteReadingTime | default "min read" }}</span
         >

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,7 +23,7 @@
         >{{ end }}
 
 
-      {{ if $.Site.Params.ShowReadingTime }}
+      {{ if and $.Site.Params.ShowReadingTime (not .Param "hideReadingTime") }}
         <span class="post-read-time"
           >— {{ .ReadingTime }} {{ $.Site.Params.MinuteReadingTime | default "min read" }}</span
         >


### PR DESCRIPTION
Changes included:
- Summary is always included in list page. And "read more" link is only displayed if the content was truncated in the first place. For shorter posts which don't get truncated, "read more" is kind of superfluous.
- Added a `hideReadingTime` param for individual pages, which can optionally hide the reading time on pages like about, contact, etc.
